### PR TITLE
Fix HelpText.Copyright get accessor

### DIFF
--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -131,7 +131,7 @@ namespace CommandLine.Text
         {
             get
             {
-                return this.heading;
+                return this.copyright;
             }
 
             set


### PR DESCRIPTION
The `HelpText.Copyright` get accessor was incorrectly returning `this.heading` instead of `this.copyright`.