### PR TITLE
Unit tests fix - removed "true" argument for bool option parameter

### DIFF
--- a/src/CommandLine.Tests/Unit/ParserTests.cs
+++ b/src/CommandLine.Tests/Unit/ParserTests.cs
@@ -129,7 +129,7 @@ namespace CommandLine.Tests.Unit
             var sut = new Parser();
 
             // Exercize system
-            var result = sut.ParseArguments<FakeOptions>(new[] { "-x", "true", "-i1", "2", "3" });
+            var result = sut.ParseArguments<FakeOptions>(new[] { "-x", "-i1", "2", "3" });
 
             // Verify outcome
             result.Value.ShouldHave().AllProperties().EqualTo(expectedOptions);


### PR DESCRIPTION
From lib code it looks like bool parameters do not accept "true" or "false" strings. Note that there is another unit test failing (issue #85). It seems to me that failing unit test is also wrong.
