### PR TITLE
Fixed failed parsing on nullable options

### DIFF
--- a/src/CommandLine.Tests/CommandLine.Tests.csproj
+++ b/src/CommandLine.Tests/CommandLine.Tests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Fakes\FakeOptionsWithNullable.cs" />
     <Compile Include="Fakes\FakeOptionsWithTwoIntegers.cs" />
     <Compile Include="Fakes\FakeInterfaceOptions.cs" />
     <Compile Include="Fakes\FakeOptionsWithHelpTextEnum.cs" />

--- a/src/CommandLine.Tests/CommandLine.Tests.csproj
+++ b/src/CommandLine.Tests/CommandLine.Tests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Fakes\FakeOptionsWithNullDefault.cs" />
     <Compile Include="Fakes\FakeOptionsWithSequence.cs" />
     <Compile Include="Fakes\FakeOptionsWithSequenceWithMinZero.cs" />
+    <Compile Include="Fakes\FakeOptionsWithSetAndNonSet.cs" />
     <Compile Include="Fakes\FakeOptionsWithTwoIntegers.cs" />
     <Compile Include="Fakes\FakeInterfaceOptions.cs" />
     <Compile Include="Fakes\FakeOptionsWithHelpTextEnum.cs" />

--- a/src/CommandLine.Tests/CommandLine.Tests.csproj
+++ b/src/CommandLine.Tests/CommandLine.Tests.csproj
@@ -60,6 +60,7 @@
     </Compile>
     <Compile Include="Fakes\FakeOptionsWithNullable.cs" />
     <Compile Include="Fakes\FakeOptionsWithNullDefault.cs" />
+    <Compile Include="Fakes\FakeOptionsWithSequence.cs" />
     <Compile Include="Fakes\FakeOptionsWithSequenceWithMinZero.cs" />
     <Compile Include="Fakes\FakeOptionsWithTwoIntegers.cs" />
     <Compile Include="Fakes\FakeInterfaceOptions.cs" />

--- a/src/CommandLine.Tests/CommandLine.Tests.csproj
+++ b/src/CommandLine.Tests/CommandLine.Tests.csproj
@@ -60,6 +60,7 @@
     </Compile>
     <Compile Include="Fakes\FakeOptionsWithNullable.cs" />
     <Compile Include="Fakes\FakeOptionsWithNullDefault.cs" />
+    <Compile Include="Fakes\FakeOptionsWithSequenceWithMinZero.cs" />
     <Compile Include="Fakes\FakeOptionsWithTwoIntegers.cs" />
     <Compile Include="Fakes\FakeInterfaceOptions.cs" />
     <Compile Include="Fakes\FakeOptionsWithHelpTextEnum.cs" />

--- a/src/CommandLine.Tests/CommandLine.Tests.csproj
+++ b/src/CommandLine.Tests/CommandLine.Tests.csproj
@@ -59,6 +59,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Fakes\FakeOptionsWithNullable.cs" />
+    <Compile Include="Fakes\FakeOptionsWithNullDefault.cs" />
     <Compile Include="Fakes\FakeOptionsWithTwoIntegers.cs" />
     <Compile Include="Fakes\FakeInterfaceOptions.cs" />
     <Compile Include="Fakes\FakeOptionsWithHelpTextEnum.cs" />

--- a/src/CommandLine.Tests/Fakes/FakeOptionsWithNullDefault.cs
+++ b/src/CommandLine.Tests/Fakes/FakeOptionsWithNullDefault.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace CommandLine.Tests.Fakes
+{
+    class FakeOptionsWithNullDefault
+    {
+        [Option('i', DefaultValue = null)]
+        public IEnumerable<int> IntSequence
+		{
+			get { return intSequence; }
+			set { intSequence = value; }
+		}
+		private IEnumerable<int> intSequence;
+    }
+}

--- a/src/CommandLine.Tests/Fakes/FakeOptionsWithNullDefault.cs
+++ b/src/CommandLine.Tests/Fakes/FakeOptionsWithNullDefault.cs
@@ -5,11 +5,6 @@ namespace CommandLine.Tests.Fakes
     class FakeOptionsWithNullDefault
     {
         [Option('i', DefaultValue = null)]
-        public IEnumerable<int> IntSequence
-		{
-			get { return intSequence; }
-			set { intSequence = value; }
-		}
-		private IEnumerable<int> intSequence;
+        public IEnumerable<int> IntSequence { get; set; }
     }
 }

--- a/src/CommandLine.Tests/Fakes/FakeOptionsWithNullable.cs
+++ b/src/CommandLine.Tests/Fakes/FakeOptionsWithNullable.cs
@@ -1,0 +1,11 @@
+﻿namespace CommandLine.Tests.Fakes
+{
+    class FakeOptionsWithNullable
+    {
+        [Option('n')]
+        public int? NullableIntValue { get; set; }
+
+        [Option('c')]
+        public Colors? NullableColorsValue { get; set; }
+    }
+}

--- a/src/CommandLine.Tests/Fakes/FakeOptionsWithSequence.cs
+++ b/src/CommandLine.Tests/Fakes/FakeOptionsWithSequence.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace CommandLine.Tests.Fakes
+{
+    class FakeOptionsWithSequence
+    {
+        [Option('i')]
+        public IEnumerable<int> IntSequence { get; set; }
+    }
+}

--- a/src/CommandLine.Tests/Fakes/FakeOptionsWithSequenceWithMinZero.cs
+++ b/src/CommandLine.Tests/Fakes/FakeOptionsWithSequenceWithMinZero.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace CommandLine.Tests.Fakes
+{
+    class FakeOptionsWithSequenceWithMinZero
+    {
+        [Option('i', Min = 0)]
+        public IEnumerable<int> IntSequence { get; set; }
+    }
+}

--- a/src/CommandLine.Tests/Fakes/FakeOptionsWithSetAndNonSet.cs
+++ b/src/CommandLine.Tests/Fakes/FakeOptionsWithSetAndNonSet.cs
@@ -1,0 +1,11 @@
+﻿namespace CommandLine.Tests.Fakes
+{
+	class FakeOptionsWithSetAndNonSet
+	{
+		[Option('s', "set", SetName = "Set")]
+		public bool Set { get; set; }
+
+		[Option('n', "nonset")]
+		public bool NonSet { get; set; }
+	}
+}

--- a/src/CommandLine.Tests/Unit/Core/OptionMapperTests.cs
+++ b/src/CommandLine.Tests/Unit/Core/OptionMapperTests.cs
@@ -24,7 +24,7 @@ namespace CommandLine.Tests.Unit.Core
             var specProps = new[]
                 {
                     SpecificationProperty.Create(
-                        new OptionSpecification("x", string.Empty, false, string.Empty, -1, -1, Maybe.Nothing<object>(), typeof(bool), string.Empty, string.Empty, new List<string>()), 
+                        new OptionSpecification("x", string.Empty, false, string.Empty, -1, -1, Maybe.Nothing<object>(), false, typeof(bool), string.Empty, string.Empty, new List<string>()), 
                         typeof(FakeOptions).GetProperties().Single(p => p.Name.Equals("BoolValue", StringComparison.Ordinal)),
                         Maybe.Nothing<object>())
                 };

--- a/src/CommandLine.Tests/Unit/Core/TokenPartitionerTests.cs
+++ b/src/CommandLine.Tests/Unit/Core/TokenPartitionerTests.cs
@@ -20,8 +20,8 @@ namespace CommandLine.Tests.Unit.Core
                 };
             var specs =new[]
                 {
-                    new OptionSpecification(string.Empty, "stringvalue", false, string.Empty, -1, -1, null, typeof(string), string.Empty, string.Empty, new List<string>()),
-                    new OptionSpecification("i", string.Empty, false, string.Empty, 3, 4, null, typeof(IEnumerable<int>), string.Empty, string.Empty, new List<string>())
+                    new OptionSpecification(string.Empty, "stringvalue", false, string.Empty, -1, -1, null, false, typeof(string), string.Empty, string.Empty, new List<string>()),
+                    new OptionSpecification("i", string.Empty, false, string.Empty, 3, 4, null, false, typeof(IEnumerable<int>), string.Empty, string.Empty, new List<string>())
                 };
 
             // Exercize system 
@@ -46,8 +46,8 @@ namespace CommandLine.Tests.Unit.Core
                 };
             var specs =new[]
                 {
-                    new OptionSpecification(string.Empty, "stringvalue", false, string.Empty, -1, -1, null, typeof(string), string.Empty, string.Empty, null),
-                    new OptionSpecification("i", string.Empty, false, string.Empty, 3, 4, null, typeof(IEnumerable<int>), string.Empty, string.Empty, null)
+                    new OptionSpecification(string.Empty, "stringvalue", false, string.Empty, -1, -1, null, false, typeof(string), string.Empty, string.Empty, null),
+                    new OptionSpecification("i", string.Empty, false, string.Empty, 3, 4, null, false, typeof(IEnumerable<int>), string.Empty, string.Empty, null)
                 };
 
             // Exercize system 

--- a/src/CommandLine.Tests/Unit/ParserTests.cs
+++ b/src/CommandLine.Tests/Unit/ParserTests.cs
@@ -261,5 +261,20 @@ namespace CommandLine.Tests.Unit
             Assert.Null(result.Value.IntSequence);
             // Teardown
         }
+
+        [Fact]
+        public void Parse_allow_min_equal_zero()
+        {
+            // Fixture setup
+            var sut = new Parser();
+
+            // Exercize system
+            var result = sut.ParseArguments<FakeOptionsWithSequenceWithMinZero>(new[] { "-i" });
+
+            // Verify outcome
+            Assert.NotNull(result.Value.IntSequence);
+            Assert.Empty(result.Value.IntSequence);
+            // Teardown
+        }
     }
 }

--- a/src/CommandLine.Tests/Unit/ParserTests.cs
+++ b/src/CommandLine.Tests/Unit/ParserTests.cs
@@ -89,7 +89,7 @@ namespace CommandLine.Tests.Unit
             var sut = new Parser();
 
             // Exercize system
-            var result = sut.ParseArguments<FakeOptions>(new[] { "--stringvalue", "strvalue", "--intsequence", "1", "2", "3" });
+            var result = sut.ParseArguments<FakeOptions>(new[] { "--stringvalue", "strvalue", "-i", "1", "2", "3" });
 
             // Verify outcome
             result.Value.ShouldHave().AllProperties().EqualTo(expectedOptions);

--- a/src/CommandLine.Tests/Unit/ParserTests.cs
+++ b/src/CommandLine.Tests/Unit/ParserTests.cs
@@ -243,8 +243,8 @@ namespace CommandLine.Tests.Unit
             var result = sut.ParseArguments<FakeOptionsWithNullable>(new[] { "-n", "60", "-c", "Red" });
 
             // Verify outcome
+            Assert.Empty(result.Errors);
             result.Value.ShouldHave().AllProperties().EqualTo(expectedOptions);
-            Assert.False(result.Errors.Any());
             // Teardown
         }
 
@@ -260,6 +260,25 @@ namespace CommandLine.Tests.Unit
             // Verify outcome
             Assert.NotNull(result.Value.IntSequence);
             Assert.Empty(result.Value.IntSequence);
+            // Teardown
+        }
+
+        [Fact]
+        public void Parse_check_nonempty_sequence()
+        {
+            // Fixture setup
+            var expectedOptions = new FakeOptionsWithSequence
+            {
+                IntSequence = new[] { 60, 120 }
+            };
+            var sut = new Parser();
+
+            // Exercize system
+            var result = sut.ParseArguments<FakeOptionsWithSequence>(new[] { "-i", "60", "120" });
+
+            // Verify outcome
+            Assert.Empty(result.Errors);
+            result.Value.ShouldHave().AllProperties().EqualTo(expectedOptions);
             // Teardown
         }
 

--- a/src/CommandLine.Tests/Unit/ParserTests.cs
+++ b/src/CommandLine.Tests/Unit/ParserTests.cs
@@ -227,5 +227,25 @@ namespace CommandLine.Tests.Unit
             Assert.False(result.Errors.Any());
             // Teardown
         }
+
+        [Fact]
+        public void Parse_nullable_options()
+        {
+            // Fixture setup
+            var expectedOptions = new FakeOptionsWithNullable
+            {
+                NullableIntValue = 60,
+                NullableColorsValue = Colors.Red
+            };
+            var sut = new Parser();
+
+            // Exercize system
+            var result = sut.ParseArguments<FakeOptionsWithNullable>(new[] { "-n", "60", "-c", "Red" });
+
+            // Verify outcome
+            result.Value.ShouldHave().AllProperties().EqualTo(expectedOptions);
+            Assert.False(result.Errors.Any());
+            // Teardown
+        }
     }
 }

--- a/src/CommandLine.Tests/Unit/ParserTests.cs
+++ b/src/CommandLine.Tests/Unit/ParserTests.cs
@@ -305,5 +305,19 @@ namespace CommandLine.Tests.Unit
             Assert.Empty(result.Value.IntSequence);
             // Teardown
         }
+
+        [Fact]
+        public void Parse_allow_set_option_with_non_set()
+        {
+            // Fixture setup
+            var sut = new Parser();
+
+            // Exercize system
+            var result = sut.ParseArguments<FakeOptionsWithSetAndNonSet>(new[] { "-s", "-n" });
+
+            // Verify outcome
+            Assert.Empty(result.Errors);
+            // Teardown
+        }
     }
 }

--- a/src/CommandLine.Tests/Unit/ParserTests.cs
+++ b/src/CommandLine.Tests/Unit/ParserTests.cs
@@ -297,7 +297,7 @@ namespace CommandLine.Tests.Unit
         }
 
         [Fact]
-        public void Parse_reject__sequence_without_values()
+        public void Parse_reject_sequence_without_values()
         {
             // Fixture setup
             var sut = new Parser();
@@ -311,7 +311,7 @@ namespace CommandLine.Tests.Unit
         }
 
         [Fact]
-        public void Parse_allow_min_equal_zero()
+        public void Parse_allow_min_equal_zero_empty()
         {
             // Fixture setup
             var sut = new Parser();
@@ -322,6 +322,25 @@ namespace CommandLine.Tests.Unit
             // Verify outcome
             Assert.NotNull(result.Value.IntSequence);
             Assert.Empty(result.Value.IntSequence);
+            // Teardown
+        }
+
+        [Fact]
+        public void Parse_allow_min_equal_zero_nonempty()
+        {
+            // Fixture setup
+            var expectedOptions = new FakeOptionsWithSequence
+            {
+                IntSequence = new[] { 60, 120 }
+            };
+            var sut = new Parser();
+
+            // Exercize system
+            var result = sut.ParseArguments<FakeOptionsWithSequenceWithMinZero>(new[] { "-i", "60", "120" });
+
+            // Verify outcome
+            Assert.Empty(result.Errors);
+            result.Value.ShouldHave().AllProperties().EqualTo(expectedOptions);
             // Teardown
         }
 

--- a/src/CommandLine.Tests/Unit/ParserTests.cs
+++ b/src/CommandLine.Tests/Unit/ParserTests.cs
@@ -249,6 +249,21 @@ namespace CommandLine.Tests.Unit
         }
 
         [Fact]
+        public void Parse_check_empty_sequence()
+        {
+            // Fixture setup
+            var sut = new Parser();
+
+            // Exercize system
+            var result = sut.ParseArguments<FakeOptionsWithSequence>(new string[0]);
+
+            // Verify outcome
+            Assert.NotNull(result.Value.IntSequence);
+            Assert.Empty(result.Value.IntSequence);
+            // Teardown
+        }
+
+        [Fact]
         public void Parse_allow_null_default_value()
         {
             // Fixture setup
@@ -259,6 +274,20 @@ namespace CommandLine.Tests.Unit
 
             // Verify outcome
             Assert.Null(result.Value.IntSequence);
+            // Teardown
+        }
+
+        [Fact]
+        public void Parse_reject__sequence_without_values()
+        {
+            // Fixture setup
+            var sut = new Parser();
+
+            // Exercize system
+            var result = sut.ParseArguments<FakeOptionsWithSequence>(new[] { "-i" });
+
+            // Verify outcome
+            Assert.NotEmpty(result.Errors);
             // Teardown
         }
 

--- a/src/CommandLine.Tests/Unit/ParserTests.cs
+++ b/src/CommandLine.Tests/Unit/ParserTests.cs
@@ -247,5 +247,19 @@ namespace CommandLine.Tests.Unit
             Assert.False(result.Errors.Any());
             // Teardown
         }
+
+        [Fact]
+        public void Parse_allow_null_default_value()
+        {
+            // Fixture setup
+            var sut = new Parser();
+
+            // Exercize system
+            var result = sut.ParseArguments<FakeOptionsWithNullDefault>(new string[0]);
+
+            // Verify outcome
+            Assert.Null(result.Value.IntSequence);
+            // Teardown
+        }
     }
 }

--- a/src/CommandLine/Core/InstanceBuilder.cs
+++ b/src/CommandLine/Core/InstanceBuilder.cs
@@ -65,7 +65,7 @@ namespace CommandLine.Core
 
             var valueSpecProps = ValueMapper.MapValues(
                 (from pt in specProps where pt.Specification.IsValue() select pt),
-                    partitions.Item2,
+                partitions.Item2,
                 (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, parsingCulture));
 
             var missingValueErrors = from token in partitions.Item3

--- a/src/CommandLine/Core/InstanceBuilder.cs
+++ b/src/CommandLine/Core/InstanceBuilder.cs
@@ -80,12 +80,12 @@ namespace CommandLine.Core
                     sp => sp.Value.FromJust())
                 .SetProperties(specPropsWithValue,
                     sp => sp.Value.IsNothing() && sp.Specification.DefaultValue.IsJust(),
-                    sp => sp.Specification.DefaultValue.FromJust())
-                .SetProperties(specPropsWithValue,
-                    sp => sp.Value.IsNothing()
-                        && sp.Specification.ConversionType.ToDescriptor() == DescriptorType.Sequence
-                        && sp.Specification.DefaultValue.MatchNothing(),
-                    sp => sp.Property.PropertyType.GetGenericArguments().Single().CreateEmptyArray());
+                    sp => sp.Specification.DefaultValue.FromJust());
+                //.SetProperties(specPropsWithValue,
+                //    sp => sp.Value.IsNothing()
+                //        && sp.Specification.ConversionType.ToDescriptor() == DescriptorType.Sequence
+                //        && sp.Specification.DefaultValue.MatchNothing(),
+                //    sp => sp.Property.PropertyType.GetGenericArguments().Single().CreateEmptyArray());
 
             var validationErrors = specPropsWithValue.Validate(SpecificationPropertyRules.Lookup)
                 .OfType<Just<Error>>().Select(e => e.Value);

--- a/src/CommandLine/Core/InstanceBuilder.cs
+++ b/src/CommandLine/Core/InstanceBuilder.cs
@@ -92,12 +92,13 @@ namespace CommandLine.Core
                     sp => sp.Property.PropertyType.GetGenericArguments().Single().CreateEmptyArray())
                 .SetProperties(specPropsWithValue,
                     sp => sp.Value.IsNothing() && sp.Specification.DefaultValue.IsJust(),
-                    sp => sp.Specification.DefaultValue.FromJust());
-                //.SetProperties(specPropsWithValue,
-                //    sp => sp.Value.IsNothing()
-                //        && sp.Specification.ConversionType.ToDescriptor() == DescriptorType.Sequence
-                //        && sp.Specification.DefaultValue.MatchNothing(),
-                //    sp => sp.Property.PropertyType.GetGenericArguments().Single().CreateEmptyArray());
+                    sp => sp.Specification.DefaultValue.FromJust())
+                .SetProperties(specPropsWithValue,
+                    sp => sp.Value.IsNothing()
+                        && sp.Specification.ConversionType.ToDescriptor() == DescriptorType.Sequence
+                        && !sp.Specification.DefaulSpecified
+                        && sp.Specification.DefaultValue.MatchNothing(),
+                    sp => sp.Property.PropertyType.GetGenericArguments().Single().CreateEmptyArray());
 
             var validationErrors = specPropsWithValue.Validate(SpecificationPropertyRules.Lookup)
                 .OfType<Just<Error>>().Select(e => e.Value);

--- a/src/CommandLine/Core/InstanceBuilder.cs
+++ b/src/CommandLine/Core/InstanceBuilder.cs
@@ -69,8 +69,17 @@ namespace CommandLine.Core
                 (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, parsingCulture));
 
             var missingValueErrors = from token in partitions.Item3
+                                     let optionSpec = optionSpecs.Single(o => token.Text.MatchName(o.ShortName, o.LongName, nameComparer))
+                                     where !(optionSpec.ConversionType.ToDescriptor() == DescriptorType.Sequence && optionSpec.Min == 0)
                                      select new MissingValueOptionError(
                                          NameInfo.FromOptionSpecification(optionSpecs.Single(o => token.Text.MatchName(o.ShortName, o.LongName, nameComparer))));
+
+            var emptyOptionSpecProps = from sp in optionSpecProps.Value
+                                       let o = (OptionSpecification) sp.Specification
+                                       where tokens.Count(token => token.Text.MatchName(o.ShortName, o.LongName, nameComparer)) == 1
+                                           && o.ConversionType.ToDescriptor() == DescriptorType.Sequence
+                                           && o.Min == 0
+                                       select sp;
 
             var specPropsWithValue = optionSpecProps.Value.Concat(valueSpecProps.Value);
 
@@ -78,6 +87,9 @@ namespace CommandLine.Core
                 .SetProperties(specPropsWithValue,
                     sp => sp.Value.IsJust(),
                     sp => sp.Value.FromJust())
+                .SetProperties(emptyOptionSpecProps,
+                    sp => sp.Value.IsNothing(),
+                    sp => sp.Property.PropertyType.GetGenericArguments().Single().CreateEmptyArray())
                 .SetProperties(specPropsWithValue,
                     sp => sp.Value.IsNothing() && sp.Specification.DefaultValue.IsJust(),
                     sp => sp.Specification.DefaultValue.FromJust());

--- a/src/CommandLine/Core/OptionSpecification.cs
+++ b/src/CommandLine/Core/OptionSpecification.cs
@@ -14,8 +14,8 @@ namespace CommandLine.Core
         private readonly string metaValue;
         private readonly System.Collections.Generic.IEnumerable<string> enumValues;
 
-        public OptionSpecification(string shortName, string longName, bool required, string setName, int min, int max, Maybe<object> defaultValue, System.Type conversionType, string helpText, string metaValue, System.Collections.Generic.IEnumerable<string> enumValues)
-            : base(SpecificationType.Option, required, min, max, defaultValue, conversionType)
+        public OptionSpecification(string shortName, string longName, bool required, string setName, int min, int max, Maybe<object> defaultValue, bool defaultSpecified, System.Type conversionType, string helpText, string metaValue, System.Collections.Generic.IEnumerable<string> enumValues)
+            : base(SpecificationType.Option, required, min, max, defaultValue, defaultSpecified, conversionType)
         {
             this.shortName = shortName;
             this.longName = longName;
@@ -35,6 +35,7 @@ namespace CommandLine.Core
                 attribute.Min,
                 attribute.Max,
                 attribute.DefaultValue.ToMaybe(),
+                attribute.DefaultSpecified,
                 conversionType,
                 attribute.HelpText,
                 attribute.MetaValue,

--- a/src/CommandLine/Core/Specification.cs
+++ b/src/CommandLine/Core/Specification.cs
@@ -20,18 +20,20 @@ namespace CommandLine.Core
         private readonly int min;
         private readonly int max;
         private readonly Maybe<object> defaultValue;
+        private readonly bool defaultSpecified;
         /// <summary>
         /// This information is denormalized to decouple Specification from PropertyInfo.
         /// </summary>
         private readonly System.Type conversionType;
 
-        protected Specification(SpecificationType tag, bool required, int min, int max, Maybe<object> defaultValue, System.Type conversionType)
+        protected Specification(SpecificationType tag, bool required, int min, int max, Maybe<object> defaultValue, bool defaultSpecified, System.Type conversionType)
         {
             this.tag = tag;
             this.required = required;
             this.min = min;
             this.max = max;
             this.defaultValue = defaultValue;
+            this.defaultSpecified = defaultSpecified;
             this.conversionType = conversionType;
         }
 
@@ -58,6 +60,11 @@ namespace CommandLine.Core
         public Maybe<object> DefaultValue
         {
             get { return this.defaultValue; }
+        }
+
+        public bool DefaulSpecified
+        {
+            get { return defaultSpecified; }
         }
 
         public System.Type ConversionType

--- a/src/CommandLine/Core/SpecificationExtensions.cs
+++ b/src/CommandLine/Core/SpecificationExtensions.cs
@@ -33,6 +33,7 @@ namespace CommandLine.Core
                 specification.Min,
                 specification.Max,
                 specification.DefaultValue,
+                specification.DefaulSpecified,
                 specification.ConversionType,
                 specification.HelpText,
                 specification.MetaValue,

--- a/src/CommandLine/Core/SpecificationGuards.cs
+++ b/src/CommandLine/Core/SpecificationGuards.cs
@@ -21,7 +21,7 @@ namespace CommandLine.Core
 
         private static Func<Specification, bool> GuardAgainstSequenceWithWrongRange()
         {
-            return spec => spec.ConversionType.ToDescriptor() == DescriptorType.Sequence && spec.Min > spec.Max;
+            return spec => spec.ConversionType.ToDescriptor() == DescriptorType.Sequence && (spec.Min > spec.Max && spec.Min > 0);
         }
 
         private static Func<Specification, bool> GuardAgainstOneCharLongName()

--- a/src/CommandLine/Core/SpecificationPropertyRules.cs
+++ b/src/CommandLine/Core/SpecificationPropertyRules.cs
@@ -20,7 +20,7 @@ namespace CommandLine.Core
         {
             return specProps =>
                 {
-                    var options = specProps.Where(sp => sp.Specification.IsOption() && sp.Value.IsJust());
+                    var options = specProps.Where(sp => sp.Specification.IsOption() && sp.Value.IsJust() && !string.IsNullOrEmpty(((OptionSpecification)sp.Specification).SetName));
                     var groups = options.GroupBy(g => ((OptionSpecification)g.Specification).SetName);
                     if (groups.Count() > 1)
                     {

--- a/src/CommandLine/Core/TokenPartitioner.cs
+++ b/src/CommandLine/Core/TokenPartitioner.cs
@@ -68,7 +68,7 @@ namespace CommandLine.Core
                         f.IsName() && s.IsValue()
                             ? typeLookup(f.Text).Return(info =>
                                    info.Item1 == DescriptorType.Sequence
-                                        ? new[] { f }.Concat(tokens.SkipWhile(t => t.Equals(f)).TakeWhile(v => v.IsValue()).Take(MaybeExtensions.Return(info.Item2, items => items, 0)))
+                                        ? new[] { f }.Concat(tokens.SkipWhile(t => t.Equals(f)).TakeWhile(v => v.IsValue()).Take(MaybeExtensions.Return(info.Item2, items => items, int.MaxValue)))
                                         : new Token[] { } , new Token[] { })
                             : new Token[] {})
                 from t in tseq

--- a/src/CommandLine/Core/TokenPartitioner.cs
+++ b/src/CommandLine/Core/TokenPartitioner.cs
@@ -64,7 +64,7 @@ namespace CommandLine.Core
             Func<string, Maybe<Tuple<DescriptorType, Maybe<int>>>> typeLookup)
         {
             return from tseq in tokens.Pairwise(
-                (f, s) =>     
+                (f, s) =>
                         f.IsName() && s.IsValue()
                             ? typeLookup(f.Text).Return(info =>
                                    info.Item1 == DescriptorType.Sequence

--- a/src/CommandLine/Core/TypeConverter.cs
+++ b/src/CommandLine/Core/TypeConverter.cs
@@ -41,6 +41,8 @@ namespace CommandLine.Core
         {
             try
             {
+                conversionType = Nullable.GetUnderlyingType(conversionType) ?? conversionType;
+
                 return Maybe.Just(
                     MatchBoolString(value)
                         ? ConvertBoolString(value)

--- a/src/CommandLine/Core/TypeLookup.cs
+++ b/src/CommandLine/Core/TypeLookup.cs
@@ -22,7 +22,7 @@ namespace CommandLine.Core
                 .ToMaybe()
                     .Map(
                         s => Tuple.Create(
-                            s.ConversionType.ToDescriptor(), (s.Min < 0 && s.Max < 0) ? Maybe.Nothing<int>() : Maybe.Just(s.Max)));
+                            s.ConversionType.ToDescriptor(), (s.Max < 0) ? Maybe.Nothing<int>() : Maybe.Just(s.Max)));
         }
     }
 }

--- a/src/CommandLine/Core/ValueSpecification.cs
+++ b/src/CommandLine/Core/ValueSpecification.cs
@@ -9,8 +9,8 @@ namespace CommandLine.Core
     {
         private readonly int index;
 
-        public ValueSpecification(int index, bool required, int min, int max, Maybe<object> defaultValue, System.Type conversionType)
-            : base(SpecificationType.Value, required, min, max, defaultValue, conversionType)
+        public ValueSpecification(int index, bool required, int min, int max, Maybe<object> defaultValue, bool defaultSpecified, System.Type conversionType)
+            : base(SpecificationType.Value, required, min, max, defaultValue, defaultSpecified, conversionType)
         {
             this.index = index;
         }
@@ -23,6 +23,7 @@ namespace CommandLine.Core
                 attribute.Min,
                 attribute.Max,
                 attribute.DefaultValue.ToMaybe(),
+                attribute.DefaultSpecified,
                 conversionType);
         }
 

--- a/src/CommandLine/OptionAttribute.cs
+++ b/src/CommandLine/OptionAttribute.cs
@@ -153,15 +153,7 @@ namespace CommandLine
         public object DefaultValue
         {
             get { return this.defaultValue; }
-            set
-            {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
-
-                this.defaultValue = value;
-            }
+            set { this.defaultValue = value; }
         }
 
         /// <summary>

--- a/src/CommandLine/OptionAttribute.cs
+++ b/src/CommandLine/OptionAttribute.cs
@@ -153,8 +153,18 @@ namespace CommandLine
         public object DefaultValue
         {
             get { return this.defaultValue; }
-            set { this.defaultValue = value; }
+
+            set
+            {
+                this.defaultValue = value;
+                DefaultSpecified = true;
+            }
         }
+
+        /// <summary>
+        /// Gets whether <see cref="DefaultValue"/> has actually been set.
+        /// </summary>
+        public bool DefaultSpecified { get; private set; }
 
         /// <summary>
         /// Gets or sets a short description of this command line option. Usually a sentence summary.

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -540,6 +540,7 @@ namespace CommandLine.Text
                        -1,
                        -1,
                        Maybe.Nothing<object>(),
+                       false,
                        typeof(bool),
                        verbTuple.Item1.HelpText,
                        string.Empty,
@@ -565,7 +566,7 @@ namespace CommandLine.Text
 
         private OptionSpecification CreateHelpEntry()
         {
-            return new OptionSpecification(string.Empty, "help", false, string.Empty, -1, -1, Maybe.Nothing<object>(), typeof(bool),
+            return new OptionSpecification(string.Empty, "help", false, string.Empty, -1, -1, Maybe.Nothing<object>(), false, typeof(bool),
                 this.sentenceBuilder.HelpCommandText(this.AddDashesToOption), string.Empty, new List<string>());
         }
 

--- a/src/CommandLine/ValueAttribute.cs
+++ b/src/CommandLine/ValueAttribute.cs
@@ -87,13 +87,14 @@ namespace CommandLine
             get { return this.defaultValue; }
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException("value");
-                }
-
                 this.defaultValue = value;
+                DefaultSpecified = true;
             }
         }
+
+        /// <summary>
+        /// Gets whether <see cref="DefaultValue"/> has actually been set.
+        /// </summary>
+        public bool DefaultSpecified { get; private set; }
     }
 }


### PR DESCRIPTION
Enum.Parse and Convert.Change type can't convert directly from string to a nullable type so I added a type conversion to the underlying type before parsing/converting takes place. Also added a unit test for nullable types as options.
